### PR TITLE
Change flatMap to compactMap

### DIFF
--- a/Sources/Glob/Glob.swift
+++ b/Sources/Glob/Glob.swift
@@ -126,7 +126,7 @@ public class Glob: Collection {
         var directories: [String]
 
         do {
-            directories = try fileManager.subpathsOfDirectory(atPath: firstPart).flatMap { subpath in
+            directories = try fileManager.subpathsOfDirectory(atPath: firstPart).compactMap { subpath in
                 let fullPath = NSString(string: firstPart).appendingPathComponent(subpath)
                 guard isDirectory(path: fullPath) else { return nil }
                 return fullPath


### PR DESCRIPTION
Quiet the `flatmap` warnings by replacing them with `compactMap`.

We use Glob for a compiled-on-demand-tool in our iOS App's build scripts. So, while compiling our iOS apps, a command line tool is built and used. During that initial tool build this warning is confusingly injected in to the iOS Build log:

```
/<REPO-PATH>/Tools/.build/checkouts/Glob/Sources/Glob/Glob.swift:129:82: warning: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value
            directories = try fileManager.subpathsOfDirectory(atPath: firstPart).flatMap { subpath in
                                                                                 ^
/<REPO-PATH>/Tools/.build/checkouts/Glob/Sources/Glob/Glob.swift:129:82: note: use 'compactMap(_:)' instead
            directories = try fileManager.subpathsOfDirectory(atPath: firstPart).flatMap { subpath in
                                                                                 ^~~~~~~
                                                                                 compactMap
```

This would fix that nicely. It would be great if you could also add a new `1.0.4` tag on master.  Thanks!