### PR TITLE
make `paths` property is public read-only; handy for coding

### DIFF
--- a/Sources/Glob/Glob.swift
+++ b/Sources/Glob/Glob.swift
@@ -65,7 +65,7 @@ public class Glob: Collection {
     private var isDirectoryCache = [String: Bool]()
 
     public let behavior: Behavior
-    var paths = [String]()
+    public private(set) var paths = [String]()
     public var startIndex: Int { return paths.startIndex }
     public var endIndex: Int   { return paths.endIndex   }
 


### PR DESCRIPTION
Make `paths` to be public read-only. It's handy for coding

```
let glob = Glob(pattern: ...)
let count = glob.paths.count
glob.paths.map { ... }

glob.paths = [ ... ]   // forbidden setter
```